### PR TITLE
Added support to :float field on model annotations

### DIFF
--- a/lib/solargraph/rails/pin_creator.rb
+++ b/lib/solargraph/rails/pin_creator.rb
@@ -109,6 +109,7 @@ module Solargraph
           'datetime' => 'ActiveSupport::TimeWithZone',
           'string' => 'String',
           'boolean' => 'Boolean',
+          'float' => 'Float',
           'text' => 'String'
         }
       end

--- a/lib/solargraph/rails/version.rb
+++ b/lib/solargraph/rails/version.rb
@@ -1,5 +1,5 @@
 module Solargraph
   module Rails
-    VERSION = '0.3.0'
+    VERSION = '0.3.1'
   end
 end

--- a/spec/lib/solargraph/rails/annotate_attributes_spec.rb
+++ b/spec/lib/solargraph/rails/annotate_attributes_spec.rb
@@ -101,6 +101,7 @@ RSpec.describe 'Attributes based on annotate' do
           #  notes                     :text
           #  name                      :string
           #  created_at                :datetime
+          #  price                     :float
           class MyModel < ApplicationRecord
         FILE
 
@@ -115,6 +116,7 @@ RSpec.describe 'Attributes based on annotate' do
         expect(attrs['notes']).to eq('String')
         expect(attrs['name']).to eq('String')
         expect(attrs['created_at']).to eq('ActiveSupport::TimeWithZone')
+        expect(attrs['price']).to eq('Float')
       end
     end
   end


### PR DESCRIPTION
I was working on a RoR personal project with some `Float` fields on many models.

I discovered that `solargraph-rails` worked fine with every other type of field, but on `Float`fields did not.

I did a search on the code using [The Silver Searcher](https://github.com/ggreer/the_silver_searcher) tool, and found out that the file `lib/solargraph/rails/pin_creator.rb` on it's last method called `type_translation` it was lacking the `'float' => 'Float'` pair on the dictionary. That's why the tool was not working.

I've built the gem locally, and tested it with my project and everything went fine. I've also changed the version number from `0.3.0` to `0.3.1` to test it locally, and prevent collisions with my previous installation. I don't know if it is worth to change the version name for such a small change, but I let it anyways.

Also, I've run the tests with `rake spec` and the 70 tests were green.

I'd like to collaborate with this project. I found it very usefull, and I believe that solargraph typechecking is turning Ruby in some strange "strong typed language", kind of something like Typescript. And there is a lot of dragons to slay, lol. I'd be glad to receive any feedback.

BTW, what does "pin_creator" means? For what I've seen in the code, the class adds the `"@return"` so the IDE extension can tell what kind of variable will return the method/variable. How can I know more about Solargraph under the hood? Any recommendations or tips? or it is better to dive on the Issues tab on this project?

Best regards,

Karl.