### PR TITLE
Point ruby workflow at PRs to main

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -10,7 +10,7 @@ name: Ruby
 on:
   workflow_dispatch: {}
   pull_request:
-    branches: [master]
+    branches: [main]
 
 jobs:
   test:


### PR DESCRIPTION
Previously, this pointed at master. Now, it points to main which is the correct branch name in this project.