### PR TITLE
Add missing db types

### DIFF
--- a/lib/solargraph/rails/model.rb
+++ b/lib/solargraph/rails/model.rb
@@ -28,6 +28,7 @@ module Solargraph
         end
 
         walker.on :send, [nil, :scope] do |ast|
+          next if ast.children[2].nil?
           name = ast.children[2].children.last
 
           method_pin =

--- a/lib/solargraph/rails/schema.rb
+++ b/lib/solargraph/rails/schema.rb
@@ -18,6 +18,8 @@ module Solargraph
         uuid: 'String',
         inet: 'IPAddr',
         citext: 'String',
+        binary: 'String',
+        timestamp: 'ActiveSupport::TimeWithZone'
       }
 
       def self.instance

--- a/spec/solargraph-rails/model_spec.rb
+++ b/spec/solargraph-rails/model_spec.rb
@@ -93,4 +93,28 @@ RSpec.describe Solargraph::Rails::Model do
       expect(pin.parameters.first.name).to eq('min_height')
     end
   end
+
+  it 'does not generate methods for variable named scope' do
+    load_string 'app/models/person.rb',
+                <<-RUBY
+                class Person < ActiveRecord::Base
+                  def some_method
+                    scope = Person.where(id: 0)
+                    scope.count
+                  end
+
+                  scope :taller_than,
+                        ->(min_height) { where('height > ?', min_height) }
+                end
+                RUBY
+
+    assert_class_method(
+      api_map,
+      'Person.taller_than',
+      ['Class<Person>']
+    ) do |pin|
+      expect(pin.parameters).not_to be_empty
+      expect(pin.parameters.first.name).to eq('min_height')
+    end
+  end
 end

--- a/spec/solargraph-rails/schema_spec.rb
+++ b/spec/solargraph-rails/schema_spec.rb
@@ -22,6 +22,8 @@ RSpec.describe Solargraph::Rails::Schema do
           t.jsonb "new_school_json"
           t.uuid "uuid"
           t.citext "some_citext"
+          t.binary "some_binary"
+          t.timestamp "some_timestamp"
 
           t.check_constraint "balance > 0"
           t.index ["some_big_id"], name: "index_accounts_on_some_big_id", unique: true
@@ -64,6 +66,8 @@ RSpec.describe Solargraph::Rails::Schema do
     assert_public_instance_method(map, "Account#old_school_json", ["Hash"])
     assert_public_instance_method(map, "Account#new_school_json", ["Hash"])
     assert_public_instance_method(map, "Account#some_citext", ["String"])
+    assert_public_instance_method(map, "Account#some_binary", ["String"])
+    assert_public_instance_method(map, "Account#some_timestamp", ["ActiveSupport::TimeWithZone"])
   end
 end
 


### PR DESCRIPTION
A couple of small fix to get this plugin to work properly in my project.

* Adds two missing types used in schemas.
* Also fix issue where this syntax would fail, when calling a method on a variable named scope:
```rb
scope = MyModel.where(id: 0)
scope.count
```

