### PR TITLE
chore: allow solargraph to upgrade beyond v0.44

### DIFF
--- a/solargraph-rails.gemspec
+++ b/solargraph-rails.gemspec
@@ -27,6 +27,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake', '~> 12.3.3'
   spec.add_development_dependency 'rspec', '~> 3.0'
 
-  spec.add_runtime_dependency 'solargraph', '~> 0.44.2'
+  spec.add_runtime_dependency 'solargraph', '>= 0.44.2'
   spec.add_runtime_dependency 'activesupport'
 end


### PR DESCRIPTION
This PR proposes allowing Solargraph to update to any future version. At this stage (of both projects) I propose restricting it only when have a confirmed upstream incompatibility that we willfully decide we're not going to fix.

Two reasons:

1. We're currently missing out on bugfixes and improvements in Solargraph
2. We have no visibility on any possible compatibility issues, and I believe the best way to get those issues reported is by exposing them to the world.

Full disclosure: I'm not at the capacity to know if there's any reason that I'm not aware of why we need to micromanage Solargraph's version. If there is, LMK how I can help.