### PR TITLE
Remove assets from gem

### DIFF
--- a/solargraph-rails.gemspec
+++ b/solargraph-rails.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
 
   spec.files =
     `git ls-files -z`.split("\x0").reject do |f|
-      f.match(%r{^(test|spec|features)/})
+      f.match(%r{^(assets|test|spec|features)/})
     end
   spec.bindir = 'exe'
   spec.executables = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }


### PR DESCRIPTION
```
$ rake build
solargraph-rails 1.0.0.pre.1 built to pkg/solargraph-rails-1.0.0.pre.1.gem.

$ du -h pkg/solargraph-rails-1.0.0.pre.1.gem

(main branch)
2.8M    pkg/solargraph-rails-1.0.0.pre.1.gem

(this branch)
 20K    pkg/solargraph-rails-1.0.0.pre.1.gem
```