### PR TITLE
Permit newer Solargraph versions

### DIFF
--- a/solargraph-rails.gemspec
+++ b/solargraph-rails.gemspec
@@ -27,6 +27,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake', '~> 12.3.3'
   spec.add_development_dependency 'rspec', '~> 3.0'
 
-  spec.add_runtime_dependency 'solargraph', '~> 0.44.2'
+  spec.add_runtime_dependency 'solargraph', '~> 0.45'
   spec.add_runtime_dependency 'activesupport'
 end


### PR DESCRIPTION
This just updates the Solargraph dependency in the gemspec to 0.45 with the ability to update to 0.46, etc. I haven't done an extensive test but it seems to be working fine in my project.