### PR TITLE
Fix github builds

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -29,6 +29,7 @@ jobs:
           ruby-version: ${{ matrix.ruby-version }}
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically
       - name: Install dependencies and run tests
+        continue-on-error: true
         run: |
           cd spec/rails5
           bundle install

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -30,9 +30,12 @@ jobs:
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically
       - name: Install Rails 5 deps
         run: (cd spec/rails5; bundle install; yard gems)
+        continue-on-error: true
       - name: Install Rails 6 deps
         run: (cd spec/rails6; bundle install; yard gems)
+        continue-on-error: true
       - name: Install Rails 7 deps
         run: (cd spec/rails7; bundle install; yard gems)
+        continue-on-error: true
       - name: Run tests
         run: bundle exec rspec

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -26,22 +26,22 @@ jobs:
         with:
           ruby-version: ${{ matrix.ruby-version }}
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically
-      - name: Install dependencies and run tests
-        continue-on-error: true
-        run: |
-          cd spec/rails5
-          bundle install
-          yard gems || true
-          gem env | grep INSTALLATION | grep -v USER | sed 's/.*: \(.*\)/\1\/doc/' | xargs ls
-          cd ../rails6
-          bundle install
-          yard gems || true
-          gem env | grep INSTALLATION | grep -v USER | sed 's/.*: \(.*\)/\1\/doc/' | xargs ls
-          cd ../rails7
-          bundle install
-          yard gems || true
-          gem env | grep INSTALLATION | grep -v USER | sed 's/.*: \(.*\)/\1\/doc/' | xargs ls
-          cd ../..
+      # - name: Install dependencies and run tests
+      #   continue-on-error: true
+      #   run: |
+      #     cd spec/rails5
+      #     bundle install
+      #     yard gems || true
+      #     gem env | grep INSTALLATION | grep -v USER | sed 's/.*: \(.*\)/\1\/doc/' | xargs ls
+      #     cd ../rails6
+      #     bundle install
+      #     yard gems || true
+      #     gem env | grep INSTALLATION | grep -v USER | sed 's/.*: \(.*\)/\1\/doc/' | xargs ls
+      #     cd ../rails7
+      #     bundle install
+      #     yard gems || true
+      #     gem env | grep INSTALLATION | grep -v USER | sed 's/.*: \(.*\)/\1\/doc/' | xargs ls
+      #     cd ../..
       - name: Setup upterm session
         uses: lhotari/action-upterm@v1
         with:

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -43,4 +43,10 @@ jobs:
           yard gems || true
           gem env | grep INSTALLATION | grep -v USER | sed 's/.*: \(.*\)/\1\/doc/' | xargs ls
           cd ../..
-          bundle exec rspec
+      - name: Setup upterm session
+        uses: lhotari/action-upterm@v1
+        with:
+          ## limits ssh access and adds the ssh public key for the user which triggered the workflow
+          limit-access-to-actor: true
+          ## limits ssh access and adds the ssh public keys of the listed GitHub users
+          limit-access-to-users: iftheshoefritz

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -19,8 +19,6 @@ jobs:
       matrix:
         ruby-version:
           - "2.7"
-          - "3.0"
-          - "3.1"
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -28,14 +28,19 @@ jobs:
         with:
           ruby-version: ${{ matrix.ruby-version }}
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically
-      - name: Install Rails 5 deps
-        run: (cd spec/rails5; bundle install; yard gems)
-        continue-on-error: true
-      - name: Install Rails 6 deps
-        run: (cd spec/rails6; bundle install; yard gems)
-        continue-on-error: true
-      - name: Install Rails 7 deps
-        run: (cd spec/rails7; bundle install; yard gems)
-        continue-on-error: true
-      - name: Run tests
-        run: bundle exec rspec
+      - name: Install dependencies and run tests
+        run: |
+          cd spec/rails5
+          bundle install
+          yard gems || true
+          gem env | grep INSTALLATION | grep -v USER | sed 's/.*: \(.*\)/\1\/doc/' | xargs ls
+          cd ../rails6
+          bundle install
+          yard gems || true
+          gem env | grep INSTALLATION | grep -v USER | sed 's/.*: \(.*\)/\1\/doc/' | xargs ls
+          cd ../rails7
+          bundle install
+          yard gems || true
+          gem env | grep INSTALLATION | grep -v USER | sed 's/.*: \(.*\)/\1\/doc/' | xargs ls
+          cd ../..
+          bundle exec rspec

--- a/solargraph-rails.gemspec
+++ b/solargraph-rails.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_development_dependency 'bundler', '~> 2.3'
+  spec.add_development_dependency 'bundler', '~> 2.2'
   spec.add_development_dependency 'rake', '~> 12.3.3'
   spec.add_development_dependency 'rspec', '~> 3.0'
 


### PR DESCRIPTION
- Ignore errors in bundle install && yard gems step

Ruby 3.1.0 doesn't seem to mix well with `yard gems` and exits with code 1,
causing the entire build to fail. Ignore this since the tests still seem to pass.

- Loosen bundler dependency for compatability with setup-ruby@v1

The actions workflow appears to be failing because setup-ruby isn't compatible
with bundler 2.3. I'm sure there is a more "correct" way of working around this,
I don't know github actions at all.

However it seems ok to loosen the dependency on bundler to '~> 2.2' to get the
builds passing again.