### PR TITLE
Remove patch num from ~> solargraph version match

### DIFF
--- a/solargraph-rails.gemspec
+++ b/solargraph-rails.gemspec
@@ -27,6 +27,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake', '~> 12.3.3'
   spec.add_development_dependency 'rspec', '~> 3.0'
 
-  spec.add_runtime_dependency 'solargraph', '~> 0.44.2'
+  spec.add_runtime_dependency 'solargraph', '~> 0.45'
   spec.add_runtime_dependency 'activesupport'
 end


### PR DESCRIPTION
`~> 0.44.2` means that solargraph 0.45 refuses to load this plugin. Either do `'>=0.44.2', '< 1.0.0'` or bump minor version and remove patch one get something similar.