### PR TITLE
Fix spec that pointed to wrong version of rails

### DIFF
--- a/spec/definitions/rails7/routes.yml
+++ b/spec/definitions/rails7/routes.yml
@@ -33,7 +33,8 @@ ActionDispatch::Routing::Mapper.attr_internal_writer:
   skip: false
 ActionDispatch::Routing::Mapper.blank?:
   types:
-  - undefined
+  - "true"
+  - "false"
   skip: false
 ActionDispatch::Routing::Mapper.cattr_accessor:
   types:
@@ -141,15 +142,16 @@ ActionDispatch::Routing::Mapper.normalize_path:
   skip: false
 ActionDispatch::Routing::Mapper.presence:
   types:
-  - undefined
+  - "Object"
   skip: false
 ActionDispatch::Routing::Mapper.presence_in:
   types:
-  - undefined
+  - "Object"
   skip: false
 ActionDispatch::Routing::Mapper.present?:
   types:
-  - undefined
+  - "true"
+  - "false"
   skip: false
 ActionDispatch::Routing::Mapper.pry:
   types:
@@ -253,7 +255,8 @@ ActionDispatch::Routing::Mapper#authenticated:
   skip: false
 ActionDispatch::Routing::Mapper#blank?:
   types:
-  - undefined
+  - "true"
+  - "false"
   skip: false
 ActionDispatch::Routing::Mapper#class_eval:
   types:
@@ -413,15 +416,16 @@ ActionDispatch::Routing::Mapper#post:
   skip: false
 ActionDispatch::Routing::Mapper#presence:
   types:
-  - undefined
+  - "Object"
   skip: false
 ActionDispatch::Routing::Mapper#presence_in:
   types:
-  - undefined
+  - "Object"
   skip: false
 ActionDispatch::Routing::Mapper#present?:
   types:
-  - undefined
+  - "true"
+  - "false"
   skip: false
 ActionDispatch::Routing::Mapper#pry:
   types:

--- a/spec/definitions/rails7/routes.yml
+++ b/spec/definitions/rails7/routes.yml
@@ -87,7 +87,7 @@ ActionDispatch::Routing::Mapper.duplicable?:
 ActionDispatch::Routing::Mapper.gem:
   types:
   - undefined
-  skip: false
+  skip: true
 ActionDispatch::Routing::Mapper.html_safe?:
   types:
   - undefined
@@ -180,7 +180,7 @@ ActionDispatch::Routing::Mapper.remove_possible_singleton_method:
 ActionDispatch::Routing::Mapper.require_dependency:
   types:
   - undefined
-  skip: false
+  skip: true
 ActionDispatch::Routing::Mapper.silence_redefinition_of_method:
   types:
   - undefined
@@ -212,7 +212,7 @@ ActionDispatch::Routing::Mapper.thread_mattr_writer:
 ActionDispatch::Routing::Mapper.to_json:
   types:
   - undefined
-  skip: false
+  skip: true
 ActionDispatch::Routing::Mapper.to_param:
   types:
   - undefined
@@ -353,7 +353,7 @@ ActionDispatch::Routing::Mapper#duplicable?:
 ActionDispatch::Routing::Mapper#gem:
   types:
   - undefined
-  skip: false
+  skip: true
 ActionDispatch::Routing::Mapper#get:
   types:
   - undefined
@@ -450,7 +450,7 @@ ActionDispatch::Routing::Mapper#redirect:
 ActionDispatch::Routing::Mapper#require_dependency:
   types:
   - undefined
-  skip: false
+  skip: true
 ActionDispatch::Routing::Mapper#resolve:
   types:
   - undefined
@@ -490,7 +490,7 @@ ActionDispatch::Routing::Mapper#shallow?:
 ActionDispatch::Routing::Mapper#to_json:
   types:
   - undefined
-  skip: false
+  skip: true
 ActionDispatch::Routing::Mapper#to_param:
   types:
   - undefined

--- a/spec/helpers.rb
+++ b/spec/helpers.rb
@@ -25,6 +25,7 @@ module Helpers
 
     skipped = 0
     typed = 0
+    errors = []
 
     definitions.each do |meth, data|
       unless meth.start_with?('.') || meth.start_with?('#')
@@ -56,8 +57,15 @@ module Helpers
       elsif data['skip']
         next
       else
-        raise "#{meth} was not found in completions despite it being listed in #{definition_name}.yml"
+        errors << meth
       end
+    end
+
+    if errors.any?
+      raise <<~STR
+        The following methods could not be found despite being listed in #{definition_name}.yml:
+        #{errors}
+      STR
     end
 
     if update

--- a/spec/helpers.rb
+++ b/spec/helpers.rb
@@ -5,8 +5,8 @@ module Helpers
     source
   end
 
-  def assert_matches_definitions(map, class_name, defition_name, update: false)
-    definitions_file = "spec/definitions/#{defition_name}.yml"
+  def assert_matches_definitions(map, class_name, definition_name, update: false)
+    definitions_file = "spec/definitions/#{definition_name}.yml"
     definitions = YAML.load_file(definitions_file)
 
     class_methods =
@@ -56,12 +56,12 @@ module Helpers
       elsif data['skip']
         next
       else
-        raise "#{meth} was not found in completions"
+        raise "#{meth} was not found in completions despite it being listed in #{definition_name}.yml"
       end
     end
 
     if update
-      File.write("spec/definitions/#{defition_name}.yml", definitions.to_yaml)
+      File.write("spec/definitions/#{definition_name}.yml", definitions.to_yaml)
     end
 
     total = definitions.keys.size

--- a/spec/solargraph-rails/devise_spec.rb
+++ b/spec/solargraph-rails/devise_spec.rb
@@ -44,4 +44,26 @@ RSpec.describe Solargraph::Rails::Devise do
     filename = './app/controllers/pages_controller.rb'
     expect(completion_at(filename, [3, 23], map)).to include("confirm")
   end
+
+  it "includes devise modules in rails7" do
+    map = use_workspace "./spec/rails7" do |root|
+      root.write_file 'app/models/awesome_user.rb', <<~RUBY
+        class AwesomeUser < ActiveRecord::Base
+          devise :registerable, :confirmable, :timeoutable, timeout_in: 12.hours
+        end
+      RUBY
+
+      root.write_file 'app/controllers/pages_controller.rb', <<~RUBY
+        class PagesController < ApplicationController
+          def index
+            curr
+            AwesomeUser.new.conf
+          end
+        end
+      RUBY
+    end
+
+    filename = './app/controllers/pages_controller.rb'
+    expect(completion_at(filename, [3, 23], map)).to include("confirm")
+  end
 end

--- a/spec/solargraph-rails/rails7_spec.rb
+++ b/spec/solargraph-rails/rails7_spec.rb
@@ -106,12 +106,12 @@ RSpec.describe 'Rails 7 API' do
   end
 
   it 'provides completions for ActionDispatch::Routing::Mapper' do
-    map = use_workspace './spec/rails6'
+    map = use_workspace './spec/rails7'
 
     assert_matches_definitions(
       map,
       'ActionDispatch::Routing::Mapper',
-      'rails6/routes'
+      'rails7/routes'
     )
   end
 


### PR DESCRIPTION
This spec should have pointed to rails7/routes.yml instead of rails6/routes.yml