### PR TITLE
Split CI jobs for more granular control

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -20,12 +20,12 @@ jobs:
       matrix:
         ruby-version:
           - "2.7"
-          #- "3.0"
+          - "3.0"
         solargraph-version:
           - "0.44.3"
-          #- "0.45.0"
-          #- "0.46.0"
-          #- "0.47.2"
+          - "0.45.0"
+          - "0.46.0"
+          - "0.47.2"
       fail-fast: false
 
     steps:

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -20,7 +20,13 @@ jobs:
       matrix:
         ruby-version:
           - "2.7"
-          - "3.0"
+          #- "3.0"
+        solargraph-version:
+          - "0.44.3"
+          #- "0.45.0"
+          #- "0.46.0"
+          #- "0.47.2"
+      fail-fast: false
 
     steps:
       - uses: actions/checkout@v2
@@ -32,5 +38,8 @@ jobs:
           path: |
             /home/runner/.rvm
             /home/runner/.yardoc
-      - name: Prepare Ruby
-        run: /bin/bash ./ci.sh ${{ matrix.ruby-version }}
+            #/usr/local/rvm/
+      #- name: Setup upterm session
+      #  uses: lhotari/action-upterm@v1
+      - name: Test
+        run: "/bin/bash ./ci.sh ${{ matrix.ruby-version }} ${{ matrix.solargraph-version}}"

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -14,7 +14,8 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    # older versions of Ruby want openssl1 which is not on ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         ruby-version:

--- a/ci.sh
+++ b/ci.sh
@@ -1,21 +1,34 @@
 #!/bin/bash
 set -e
+# when running in github actions:
 RVM_PATH=/home/runner/.rvm
-ARGS=("$@")
+# when running locally using act:
+#RVM_PATH=/usr/local/rvm
+MATRIX_RUBY_VERSION=$1
+MATRIX_SOLARGRAPH_VERSION=$2
 
 if [[ ! -d $RVM_PATH ]]; then
-  curl -sSL https://get.rvm.io | bash
+  # this fetches the develop version; using -s stable should fetch the latest stable, but has a gpg error:
+  curl -sSL https://get.rvm.io | bash -s
 fi
 
+# when running in github actions:
 source /home/runner/.rvm/scripts/rvm
+# when running locally in Act container:
+#source /usr/local/rvm/scripts/rvm
 
-rvm install ruby $ARGS
-rvm use $ARGS
+
+#rvm package install openssl # hack because ubuntu won't give us openSSL
+rvm install ruby $MATRIX_RUBY_VERSION
+rvm use $MATRIX_RUBY_VERSION
 gem install bundler
 
-(cd spec/rails5; bundle install; yard gems)
-(cd spec/rails6; bundle install; yard gems)
-(cd spec/rails7; bundle install; yard gems)
+echo "s/gem 'solargraph'/gem 'solargraph', '${MATRIX_SOLARGRAPH_VERSION}'/" > command.sed
+
+(cd spec/rails5; sed -i -f ../../command.sed Gemfile; cat Gemfile; bundle install; yard gems)
+(cd spec/rails6; sed -i -f ../../command.sed Gemfile; cat Gemfile; bundle install; yard gems)
+(cd spec/rails7; sed -i -f ../../command.sed Gemfile; cat Gemfile; bundle install; yard gems)
 
 bundle install
+
 bundle exec rspec


### PR DESCRIPTION
This should allow all the rails tests to run against specific versions of solargraph, each in a separate jobs. More testing work is done but it should proceed in the the same amount of time because everything runs in parallel.