### PR TITLE
Support tsvector type columns in migrations

### DIFF
--- a/lib/solargraph/rails/schema.rb
+++ b/lib/solargraph/rails/schema.rb
@@ -19,6 +19,7 @@ module Solargraph
         inet: 'IPAddr',
         citext: 'String',
         binary: 'String',
+        tsvector: 'String',
         timestamp: 'ActiveSupport::TimeWithZone'
       }
 


### PR DESCRIPTION
tsvector is Postgresql specific column used for fulltext search. Even though it is postgresql specific it is supported out-of-the-box by postgresql adapter of active_record.