### PR TITLE
Support Ruby >= 3.1, Solargraph >= 0.48

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -14,18 +14,14 @@ on:
 
 jobs:
   test:
-    # older versions of Ruby want openssl1 which is not on ubuntu-latest
-    runs-on: ubuntu-20.04
     strategy:
       matrix:
         ruby-version:
-          - "2.7"
-          - "3.0"
+          - "3.1"
+          - "3.2"
         solargraph-version:
-          - "0.44.3"
-          - "0.45.0"
-          - "0.46.0"
-          - "0.47.2"
+          - "0.48.0"
+          - "0.49.0"
       fail-fast: false
 
     steps:


### PR DESCRIPTION
I've been giving this project a bit of attention again recently, and my personal feeling is that the testing matrix is over-ambitious for so few contributors. 

As noted in #55, CI is currently failing and it seems like nobody really knows why. IMO there's no reason to debug on a year old version of Solargraph.

I'd also like to put Rails versions in the test matrix, drop support for Rails 5 immediately, and maybe even Rails 6 too.

I personally am not working on any apps older than Rails 7 and CRuby 3.1, and I have zero reason to spend time making tests pass on older versions.