### PR TITLE
Resolve incompatibility with Rails 7.1.

### DIFF
--- a/lib/solargraph-rails.rb
+++ b/lib/solargraph-rails.rb
@@ -1,4 +1,5 @@
 require 'solargraph'
+require 'active_support'
 require 'active_support/core_ext/string/inflections'
 
 require_relative 'solargraph/rails/util.rb'

--- a/lib/solargraph/rails/schema.rb
+++ b/lib/solargraph/rails/schema.rb
@@ -87,7 +87,7 @@ module Solargraph
 
       def infer_table_names(ns)
         table_name = ns.name.tableize
-        if ns.namespace.present?
+        if ns.namespace && !ns.namespace.empty?
           [ns.path.tableize.tr('/', '_'), table_name]
         else
           [table_name]


### PR DESCRIPTION
solargraph-rails causes an error when a project users Rails 7.1. This is caused by the lack of "present?" method in schema.rb.

Details:
- ActiveSupport does not guarantee providing "present?" method when a user requires 'active_support/core_ext/string/inflections'.
- Therefore, I replace `ns.namespace.present?` with `ns.namespace && !ns.namespace.empty?`.
- I also add `require 'activesupport'` to "solargraph-rails.rb" because a user should add `require 'activesupport'` even if he/she uses partial functions provided by ActiveSupport according to the following article.  
  https://guides.rubyonrails.org/active_support_core_extensions.html