### PR TITLE
Support writers in Rails models

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -20,9 +20,11 @@ jobs:
         ruby-version:
           - "3.1"
           - "3.2"
+          - "3.3"
         solargraph-version:
           - "0.48.0"
           - "0.49.0"
+          - "0.50.0"
       fail-fast: false
 
     steps:

--- a/lib/solargraph/rails/annotate.rb
+++ b/lib/solargraph/rails/annotate.rb
@@ -35,6 +35,16 @@ module Solargraph
               location:
                 Solargraph::Location.new(source_map.filename, snip.range)
             )
+
+          pins <<
+            Util.build_public_method(
+              ns,
+              "#{name}=",
+              types: [ruby_type],
+              params: { 'value' => [ruby_type] },
+              location:
+                Solargraph::Location.new(source_map.filename, snip.range)
+            )
         end
 
         pins

--- a/lib/solargraph/rails/util.rb
+++ b/lib/solargraph/rails/util.rb
@@ -5,6 +5,7 @@ module Solargraph
         ns,
         name,
         types: nil,
+        params: {},
         location: nil,
         attribute: false,
         scope: :instance
@@ -18,11 +19,27 @@ module Solargraph
         }
 
         comments = []
+        params.each do |name, types|
+          comments << "@param [#{types.join(',')}] #{name}"
+        end
         comments << "@return [#{types.join(',')}]" if types
 
         opts[:comments] = comments.join("\n")
 
-        Solargraph::Pin::Method.new(**opts)
+        m = Solargraph::Pin::Method.new(**opts)
+        parameters = params.map do |name, type|
+            Solargraph::Pin::Parameter.new(
+              location: nil,
+              closure: m,
+              comments: '',
+              name: name,
+              presence: nil,
+              decl: :arg,
+              asgn_code: nil
+            )
+        end
+        m.parameters.concat(parameters)
+        m
       end
 
       def self.build_module_include(ns, module_name, location)

--- a/spec/helpers.rb
+++ b/spec/helpers.rb
@@ -132,11 +132,19 @@ module Helpers
     map
   end
 
-  def assert_public_instance_method(map, query, return_type, &block)
+  def assert_public_instance_method(map, query, return_type, args: {}, &block)
     pin = find_pin(query, map)
     expect(pin).to_not be_nil
     expect(pin.scope).to eq(:instance)
     expect(pin.return_type.map(&:tag)).to eq(return_type)
+    args.each_pair do |name, type|
+      expect(parameter = pin.parameters.find { _1.name == name.to_s }).to_not be_nil
+      expect(parameter.return_type.tag).to eq(type)
+    end
+    pin.parameters.each do |param|
+      expect(args).to have_key(param.name.to_sym)
+      expect(param.return_type.tag).to eq(args[param.name.to_sym])
+    end
 
     yield pin if block_given?
   end

--- a/spec/solargraph-rails/annotate_spec.rb
+++ b/spec/solargraph-rails/annotate_spec.rb
@@ -25,6 +25,8 @@ RSpec.describe Solargraph::Rails::Annotate do
     end
 
     assert_public_instance_method(api_map, 'MyModel#start_date', ['Date'])
+    assert_public_instance_method(api_map, 'MyModel#start_date=', ['Date'],
+                                  args: { value: 'Date' })
     assert_public_instance_method(
       api_map,
       'MyModel#living_expenses',

--- a/spec/solargraph-rails/schema_spec.rb
+++ b/spec/solargraph-rails/schema_spec.rb
@@ -55,6 +55,8 @@ RSpec.describe Solargraph::Rails::Schema do
     end
 
     assert_public_instance_method(map, "Account#balance", ["BigDecimal"])
+    assert_public_instance_method(map, "Account#balance=", ["BigDecimal"],
+                                  args: { value: 'BigDecimal' })
     assert_public_instance_method(map, "Account#some_int", ["Integer"])
     assert_public_instance_method(map, "Account#some_date", ["Date"])
     assert_public_instance_method(map, "Account#some_big_id", ["Integer"])
@@ -129,4 +131,3 @@ RSpec.describe Solargraph::Rails::Schema do
     assert_public_instance_method(map, 'Invoice#amount', ['BigDecimal'])
   end
 end
-


### PR DESCRIPTION
For rails models with a 'foo' column, create pins for 'foo=' as well as the existing 'foo' method.