### PR TITLE
Formally drop Ruby 3.0 support

### DIFF
--- a/solargraph-rails.gemspec
+++ b/solargraph-rails.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |spec|
   spec.bindir = 'exe'
   spec.executables = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
+  spec.required_ruby_version = '>= 3.0'
 
   spec.add_development_dependency 'bundler', '~> 2.3'
   spec.add_development_dependency 'rake', '~> 12.3.3'

--- a/solargraph-rails.gemspec
+++ b/solargraph-rails.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.bindir = 'exe'
   spec.executables = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
-  spec.required_ruby_version = '>= 3.0'
+  spec.required_ruby_version = '>= 3.1'
 
   spec.add_development_dependency 'bundler', '~> 2.3'
   spec.add_development_dependency 'rake', '~> 12.3.3'


### PR DESCRIPTION
solargraph supports ruby 3.0, but in solargraph-rails, Ruby 3.0 isn't in CI and doesn't work in practice - let's add a .gemspec requirement so that Ruby 3.0 users pull older versions of the gem until/unless we decide to add back support.