### PR TITLE
Add find_by_column methods (Dynamic Filters) & a spec util cleanup

### DIFF
--- a/lib/solargraph/rails/schema.rb
+++ b/lib/solargraph/rails/schema.rb
@@ -66,7 +66,7 @@ module Solargraph
 
           # Note on this: its the starting step of dynamic filters. Technically, you can also do Model.find_by_col1_and_col2(val1, val2)
           # However, if we start suggestion all of those possibilities, it will simply be bad UX because of having too many suggestions
-          pins << Util.build_public_method(ns, "find_by_#{column}", types: [ns, 'nil'],
+          pins << Util.build_public_method(ns, "find_by_#{column}", types: ['self', 'nil'],
                                           params: { 'value' => [type] },
                                           location: location,
                                           scope: :class)

--- a/lib/solargraph/rails/schema.rb
+++ b/lib/solargraph/rails/schema.rb
@@ -63,6 +63,13 @@ module Solargraph
           pins << Util.build_public_method(ns, "#{column}=", types: [type],
                                            params: { 'value' => [type] },
                                            location: location)
+
+          # Note on this: its the starting step of dynamic filters. Technically, you can also do Model.find_by_col1_and_col2(val1, val2)
+          # However, if we start suggestion all of those possibilities, it will simply be bad UX because of having too many suggestions
+          pins << Util.build_public_method(ns, "find_by_#{column}", types: [ns, 'nil'],
+                                          params: { 'value' => [type] },
+                                          location: location,
+                                          scope: :class)
         end
 
         if pins.any?

--- a/spec/helpers.rb
+++ b/spec/helpers.rb
@@ -203,35 +203,33 @@ module Helpers
     map
   end
 
-  def assert_public_instance_method(map, query, return_type, args: nil, &block)
+  def assert_generic_method(map, query, return_type, args: {}, scope: map.includes?("#") ? :instance : :class, &block)
     pin = find_pin(query, map)
-    expect(pin).to_not be_nil
-    expect(pin.scope).to eq(:instance)
+    expect(pin).to_not be_nil, "Expected #{query} to exist, but it doesn't"
+    expect(pin.scope).to eq(scope), "Expected #{query} to have scope #{scope}, but it has #{pin.scope}"
+
     pin_return_type = pin.return_type
     pin_return_type = pin.typify map if pin_return_type.undefined?
     pin_return_type = pin.probe map if pin_return_type.undefined?
-    expect(pin_return_type.map(&:tag)).to eq(return_type) #     , ->() { "Was expecting return_type=#{return_type} while processing #{pin.inspect}, got #{pin.return_type.map(&:tag)}" }
-    unless args.nil?
-      args.each_pair do |name, type|
-        expect(parameter = pin.parameters.find { _1.name == name.to_s }).to_not be_nil
-        expect(parameter.return_type.tag).to eq(type)
-      end
-      pin.parameters.each do |param|
-        expect(args).to have_key(param.name.to_sym)
-        expect(param.return_type.tag).to eq(args[param.name.to_sym])
-      end
-    end
+    expect(pin_return_type.map(&:tag)).to eq(return_type)
 
-    yield pin if block_given?
+    args.each_pair do |name, type|
+      expect(parameter = pin.parameters.find { _1.name == name.to_s }).to_not be_nil, "expected #{query} param #{name} to exist, but it doesn't"
+      expect(parameter.return_type.tag).to eq(type), "expected #{query} param #{name} to return #{type} but it returns #{parameter.return_type.tag}"
+    end
+    pin.parameters.each do |param|
+      expect(args).to have_key(param.name.to_sym), "expected #{query} param #{param.name} to be expected, but it isn't"
+      # TODO: Is this necesseray? It should already be expected earlier by the arg.each_pair block
+      expect(real_type = param.return_type.tag).to eq(args[param.name.to_sym]), "expected #{query} param #{param.name} to return #{args[param.name.to_sym]} but it returns #{real_type}"
+    end
   end
 
-  def assert_class_method(map, query, return_type, &block)
-    pin = find_pin(query, map)
-    expect(pin).to_not be_nil
-    expect(pin.scope).to eq(:class)
-    expect(pin.return_type.map(&:tag)).to eq(return_type)
+  def assert_public_instance_method(map, query, return_type, args: {}, &block)
+    assert_generic_method(map, query, return_type, args: args, scope: :instance, &block)
+  end
 
-    yield pin if block_given?
+  def assert_class_method(map, query, return_type, args: {}, &block)
+    assert_generic_method(map, query, return_type, args: args, scope: :class, &block)
   end
 
   def find_pin(path, map = api_map)

--- a/spec/solargraph-rails/model_spec.rb
+++ b/spec/solargraph-rails/model_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe Solargraph::Rails::Model do
     load_string 'app/models/transaction.rb',
                 <<-RUBY
                 class Transaction < ActiveRecord::Base
-                  scope :positive, ->(arg) { where(foo: 'bar') }
+                  scope :positive, ->() { where(foo: 'bar') }
                 end
                 RUBY
 
@@ -87,7 +87,8 @@ RSpec.describe Solargraph::Rails::Model do
     assert_public_instance_method(
       api_map,
       'Person::ActiveRecord_Relation#taller_than',
-      ['Person::ActiveRecord_Relation']
+      ['Person::ActiveRecord_Relation'],
+      args: { h: 'undefined' }
     )
   end
 
@@ -114,11 +115,9 @@ RSpec.describe Solargraph::Rails::Model do
     assert_class_method(
       api_map,
       'Person.taller_than',
-      ['Person::ActiveRecord_Relation']
-    ) do |pin|
-      expect(pin.parameters).not_to be_empty
-      expect(pin.parameters.first.name).to eq('min_height')
-    end
+      ['Person::ActiveRecord_Relation'],
+      args: { min_height: 'undefined' }
+    )
   end
 
   it 'does not generate methods for variable named scope' do
@@ -135,20 +134,20 @@ RSpec.describe Solargraph::Rails::Model do
                 end
                 RUBY
 
+    # TODO: Does this test do the thing it says does?
     assert_class_method(
       api_map,
       'Person.taller_than',
-      ['Person::ActiveRecord_Relation']
-    ) do |pin|
-      expect(pin.parameters).not_to be_empty
-      expect(pin.parameters.first.name).to eq('min_height')
-    end
+      ['Person::ActiveRecord_Relation'],
+      args: { min_height: 'undefined' }
+    )
   end
 
   it 'exposes class methods as instance methods on relations', if: Solargraph::Rails::Delegate.supported? do
     load_string 'app/models/person.rb',
       <<~RUBY
       class Person < ActiveRecord::Base
+        # @param h [Numeric]
         def self.taller_than(h)
           where(height: h..)
         end
@@ -158,7 +157,8 @@ RSpec.describe Solargraph::Rails::Model do
     assert_public_instance_method(
       api_map,
       'Person::ActiveRecord_Relation#taller_than',
-      ['Person::ActiveRecord_Relation']
+      ['Person::ActiveRecord_Relation'],
+      args: { h: 'Numeric' }
     )
   end
 end

--- a/spec/solargraph-rails/schema_spec.rb
+++ b/spec/solargraph-rails/schema_spec.rb
@@ -73,7 +73,7 @@ RSpec.describe Solargraph::Rails::Schema do
     assert_public_instance_method(map, "Account#some_binary", ["String"])
     assert_public_instance_method(map, "Account#some_timestamp", ["ActiveSupport::TimeWithZone"])
 
-    assert_class_method(map, "Account.find_by_name", ["Account", "nil"], args: { value: 'String' })
+    assert_class_method(map, "Account.find_by_name", ["self", "nil"], args: { value: 'String' })
   end
 
   it 'infers prefixed table name' do

--- a/spec/solargraph-rails/schema_spec.rb
+++ b/spec/solargraph-rails/schema_spec.rb
@@ -58,10 +58,12 @@ RSpec.describe Solargraph::Rails::Schema do
     assert_public_instance_method(map, "Account#balance=", ["BigDecimal"],
                                   args: { value: 'BigDecimal' })
     assert_public_instance_method(map, "Account#some_int", ["Integer"])
+    assert_public_instance_method(map, "Account#some_int?", ["Boolean"])
     assert_public_instance_method(map, "Account#some_date", ["Date"])
     assert_public_instance_method(map, "Account#some_big_id", ["Integer"])
     assert_public_instance_method(map, "Account#name", ["String"])
     assert_public_instance_method(map, "Account#active", ["Boolean"])
+    assert_public_instance_method(map, "Account#active?", ["Boolean"])
     assert_public_instance_method(map, "Account#notes", ["String"])
     assert_public_instance_method(map, "Account#some_ip", ["IPAddr"])
     assert_public_instance_method(map, "Account#uuid", ["String"])
@@ -70,6 +72,8 @@ RSpec.describe Solargraph::Rails::Schema do
     assert_public_instance_method(map, "Account#some_citext", ["String"])
     assert_public_instance_method(map, "Account#some_binary", ["String"])
     assert_public_instance_method(map, "Account#some_timestamp", ["ActiveSupport::TimeWithZone"])
+
+    assert_class_method(map, "Account.find_by_name", ["Account", "nil"], args: { value: 'String' })
   end
 
   it 'infers prefixed table name' do


### PR DESCRIPTION
Adds `Model.find_by_{column}` method to class, per column

Technically, this isn't the full implementation of [Dynamic Filters (ie. find_by_column)](https://guides.rubyonrails.org/active_record_querying.html#dynamic-finders), but its a good start (& probably the most we should do, unless its possible to do a on demand suggestion thing)

Additionally, it adds some refactors in spec so that asserting class methods & instance methods use the same backing method. The method now also has helpful warning messages, indicating the query that went wrong