### PR TITLE
Build main branch and release tags

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -9,6 +9,11 @@ on:
   workflow_dispatch: {}
   pull_request:
     branches: [main]
+  push:
+    branches:
+      - 'main'
+    tags:
+      - 'v*'
 
 jobs:
   test:


### PR DESCRIPTION
This should help reduce cold-cache builds, as PR builds can use main's cache, but not that of other branches