### PR TITLE
Choose the definitions skip key independently of the solargraph gem source

### DIFF
--- a/spec/definitions.rb
+++ b/spec/definitions.rb
@@ -85,7 +85,18 @@ class Definitions
     )
   end
 
+  # The key that 'skip' entries in spec/definitions/*.yml are matched
+  # against.
+  #
+  # MATRIX_SOLARGRAPH_VERSION also selects a gem source in the Gemfile and a
+  # version constraint in the gemspec, so a caller that supplies its own
+  # solargraph gem (say, a path source pointing at a working tree) cannot use
+  # it to pick a key without also declaring a second solargraph gem from git.
+  # SOLARGRAPH_DEFINITIONS_KEY names the key on its own.
   def solargraph_version
+    definitions_key = ENV.fetch('SOLARGRAPH_DEFINITIONS_KEY', '')
+    return definitions_key unless definitions_key.empty?
+
     solargraph_force_ci_version = ENV.fetch('CI', nil) && ENV.fetch('MATRIX_SOLARGRAPH_VERSION', nil)
     return solargraph_force_ci_version if solargraph_force_ci_version
 


### PR DESCRIPTION
castwide/solargraph's `run_solargraph_rails_specs` job appends `gem 'solargraph', path: '${GITHUB_WORKSPACE}'`, so it has no way to select the `branch-castwide-master` skip key. Setting `MATRIX_SOLARGRAPH_VERSION=branch-castwide-master` also declares a second solargraph gem from git, colliding with the path source.

That variable drives two things: gem source in the `Gemfile`/gemspec, and skip key in `spec/definitions.rb`. This splits off the second:

```ruby
def solargraph_version
  definitions_key = ENV.fetch('SOLARGRAPH_DEFINITIONS_KEY', '')
  return definitions_key unless definitions_key.empty?

  solargraph_force_ci_version = ENV.fetch('CI', nil) && ENV.fetch('MATRIX_SOLARGRAPH_VERSION', nil)
  return solargraph_force_ci_version if solargraph_force_ci_version

  Solargraph::VERSION
end
```

Callers set `SOLARGRAPH_DEFINITIONS_KEY: branch-castwide-master`. Where the installed gem's `Solargraph::VERSION` already matches a key, as 0.60.3 does after https://github.com/iftheshoefritz/solargraph-rails/pull/208, no caller needs to set anything.

Unset or empty, the expression is the previous one, so all 13 `solargraph-version` matrix entries resolve today's key. `Gemfile`, gemspec and `test.yml` are untouched.

`ALLOW_IMPROVEMENTS` follows the new key, since the `branch-` relaxation is a property of which skip list is matched, not of which gem was installed. Under `FORCE_UPDATE` the key is also what gets written back as the skip entry.

This PR was written by Claude Code on behalf of @apiology.
