### PR TITLE
Remove the untyped Array#sum annotation

### DIFF
--- a/lib/solargraph/rails/annotations/array.rb
+++ b/lib/solargraph/rails/annotations/array.rb
@@ -1,6 +1,4 @@
 class Array
-  def sum; end
-
   # @param format [Symbol]
   # @return [String]
   def to_formatted_s(format = :some_default); end

--- a/spec/definitions/core/Array.yml
+++ b/spec/definitions/core/Array.yml
@@ -455,6 +455,7 @@ Array#sum:
   - 0.50.0
   - 0.51.2
   - 0.52.0
+  removed_in: 7.1
 Array#third:
   types:
   - undefined


### PR DESCRIPTION
**Claude:**

`arr.sum { |x| ... }` can lose the element type for the block parameter. Observed downstream on apiology/solargraph's integration branch with this plugin loaded: `key_types.sum { |t| t.items.length }` reports `Unresolved call to items` twice, at `lib/solargraph/complex_type/type_methods.rb:219`. Without the plugin the same line is clean.

`lib/solargraph/rails/annotations/array.rb` declared `def sum; end` — no parameters, no block, no `@param`, no `@return`. That contributes a third signature, `() => undefined`, to the combined `Array#sum` pin, alongside core rbs's `(?untyped init) ?{ (E e) -> untyped } -> untyped` and activesupport's own `sum(init = nil, &block)`. Core's block parameter carries `E`, the class-level type parameter, which is what gives `x` the element type; the zero-arity, blockless overload declares no block parameter at all and can win instead.

The stub adds nothing that activesupport's own definition (`lib/active_support/core_ext/enumerable.rb:314` in 7.0.10) and core rbs do not already provide, so removing it leaves only the two typed signatures.

Verified against solargraph on the integration branch with `MATRIX_RAILS_VERSION=7.0 ALLOW_IMPROVEMENTS=true`: 43 examples, 0 failures, 4 pending both before and after; the `Array` definitions coverage stats are unchanged (105 total, 100 covered, 32 typed).

This PR was written by Claude Code on behalf of @apiology.
