### PR TITLE
Add 0.60.4 skip definitions

### DIFF
--- a/.github/workflows/rails_new.yml
+++ b/.github/workflows/rails_new.yml
@@ -92,6 +92,19 @@ jobs:
             yq -yi '.exclude += ["config/boot.rb", "config/puma.rb", "config/environments/*.rb", "config/routes.rb", "db/*_schema.rb"]' .solargraph.yml
           fi
 
+          # Skipped while solargraph reports 0.60.4.
+          #
+          # config/puma.rb: "Unresolved call to >" -- Integer("5") infers
+          # Integer, nil because RBS interfaces are matched nominally.
+          # https://github.com/castwide/solargraph/pull/1266
+          #
+          # db/*_schema.rb: "Unresolved call to create_table" -- the block
+          # self type on ActiveRecord::Schema.define is dropped.
+          # https://github.com/castwide/solargraph/pull/1335
+          if [ "$(bundle exec ruby -e 'require "solargraph"; print Solargraph::VERSION')" = "0.60.4" ]; then
+            yq -yi '.exclude += ["config/puma.rb", "db/*_schema.rb"]' .solargraph.yml
+          fi
+
           bundle exec solargraph typecheck --level strong
         env:
           MATRIX_RAILS_MAJOR_VERSION: ${{ matrix.versions.rails-major }}

--- a/.github/workflows/rails_new.yml
+++ b/.github/workflows/rails_new.yml
@@ -98,11 +98,16 @@ jobs:
           # Integer, nil because RBS interfaces are matched nominally.
           # https://github.com/castwide/solargraph/pull/1266
           #
+          # config/routes.rb: "Unresolved call to get" -- get reaches the
+          # block only through the plugin cross-file @yieldreceiver stub on
+          # ActionDispatch::Routing::RouteSet#draw.
+          # https://github.com/castwide/solargraph/pull/1288
+          #
           # db/*_schema.rb: "Unresolved call to create_table" -- the block
           # self type on ActiveRecord::Schema.define is dropped.
           # https://github.com/castwide/solargraph/pull/1335
           if [ "$(bundle exec ruby -e 'require "solargraph"; print Solargraph::VERSION')" = "0.60.4" ]; then
-            yq -yi '.exclude += ["config/puma.rb", "db/*_schema.rb"]' .solargraph.yml
+            yq -yi '.exclude += ["config/puma.rb", "config/routes.rb", "db/*_schema.rb"]' .solargraph.yml
           fi
 
           bundle exec solargraph typecheck --level strong

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,9 +50,10 @@ jobs:
           - "0.59.0.dev.1"
           - "0.59.0.dev.2"
           - "0.60.3"
+          - "0.60.4"
           - "branch-castwide-master"
         exclude:
-          # solargraph 0.60.3 and castwide/solargraph master both set
+          # solargraph 0.60.3, 0.60.4 and castwide/solargraph master all set
           # required_ruby_version = '>= 3.1', so bundler cannot resolve them on Ruby 3.0
           - versions:
               ruby: "3.0"
@@ -74,6 +75,16 @@ jobs:
               rails-major: "7"
               rails-minor: "1"
             solargraph-version: "0.60.3"
+          - versions:
+              ruby: "3.0"
+              rails-major: "7"
+              rails-minor: "0"
+            solargraph-version: "0.60.4"
+          - versions:
+              ruby: "3.0"
+              rails-major: "7"
+              rails-minor: "1"
+            solargraph-version: "0.60.4"
         include:
           - versions:
               ruby: "3.2"

--- a/spec/definitions/actioncontroller.yml
+++ b/spec/definitions/actioncontroller.yml
@@ -78,6 +78,7 @@ ActionController::Base.allow_forgery_protection:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -106,6 +107,7 @@ ActionController::Base.allow_forgery_protection=:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -331,6 +333,7 @@ ActionController::Base.csrf_token_storage_strategy:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -360,6 +363,7 @@ ActionController::Base.csrf_token_storage_strategy=:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -393,6 +397,7 @@ ActionController::Base.default_asset_host_protocol:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -421,6 +426,7 @@ ActionController::Base.default_asset_host_protocol=:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -453,6 +459,7 @@ ActionController::Base.default_protect_from_forgery:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -481,6 +488,7 @@ ActionController::Base.default_protect_from_forgery=:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -509,6 +517,7 @@ ActionController::Base.default_static_extension:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -537,6 +546,7 @@ ActionController::Base.default_static_extension=:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -565,6 +575,7 @@ ActionController::Base.default_url_options:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -593,6 +604,7 @@ ActionController::Base.default_url_options=:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -621,6 +633,7 @@ ActionController::Base.default_url_options?:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -669,6 +682,7 @@ ActionController::Base.devise_group:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -692,6 +706,7 @@ ActionController::Base.duplicable?:
   - 0.51.2
   - 0.52.0
   - 0.60.3
+  - 0.60.4
   - branch-castwide-master
 ActionController::Base.enable_fragment_cache_logging:
   types:
@@ -717,6 +732,7 @@ ActionController::Base.enable_fragment_cache_logging:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -745,6 +761,7 @@ ActionController::Base.enable_fragment_cache_logging=:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -777,6 +794,7 @@ ActionController::Base.etag_with_template_digest:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -805,6 +823,7 @@ ActionController::Base.etag_with_template_digest=:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -833,6 +852,7 @@ ActionController::Base.etag_with_template_digest?:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -861,6 +881,7 @@ ActionController::Base.etaggers:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -889,6 +910,7 @@ ActionController::Base.etaggers=:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -917,6 +939,7 @@ ActionController::Base.etaggers?:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -945,6 +968,7 @@ ActionController::Base.forgery_protection_origin_check:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -973,6 +997,7 @@ ActionController::Base.forgery_protection_origin_check=:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -1001,6 +1026,7 @@ ActionController::Base.forgery_protection_strategy:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -1029,6 +1055,7 @@ ActionController::Base.forgery_protection_strategy=:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -1066,6 +1093,7 @@ ActionController::Base.fragment_cache_keys:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -1094,6 +1122,7 @@ ActionController::Base.fragment_cache_keys=:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -1122,6 +1151,7 @@ ActionController::Base.fragment_cache_keys?:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -1194,6 +1224,7 @@ ActionController::Base.helpers_path?:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -1208,6 +1239,7 @@ ActionController::Base.html_safe?:
   - 0.51.2
   - 0.52.0
   - 0.60.3
+  - 0.60.4
   - branch-castwide-master
 ActionController::Base.http_basic_authenticate_with:
   types:
@@ -1241,6 +1273,7 @@ ActionController::Base.include_all_helpers:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -1269,6 +1302,7 @@ ActionController::Base.include_all_helpers=:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -1297,6 +1331,7 @@ ActionController::Base.include_all_helpers?:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -1353,6 +1388,7 @@ ActionController::Base.log_warning_on_csrf_failure:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -1381,6 +1417,7 @@ ActionController::Base.log_warning_on_csrf_failure=:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -1474,6 +1511,7 @@ ActionController::Base.per_form_csrf_tokens:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -1502,6 +1540,7 @@ ActionController::Base.per_form_csrf_tokens=:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -1530,6 +1569,7 @@ ActionController::Base.perform_caching:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -1558,6 +1598,7 @@ ActionController::Base.perform_caching=:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -1651,6 +1692,7 @@ ActionController::Base.raise_on_open_redirects:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -1679,6 +1721,7 @@ ActionController::Base.raise_on_open_redirects=:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -1723,6 +1766,7 @@ ActionController::Base.render:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -1755,6 +1799,7 @@ ActionController::Base.request_forgery_protection_token:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -1783,6 +1828,7 @@ ActionController::Base.request_forgery_protection_token=:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -1819,6 +1865,7 @@ ActionController::Base.rescue_handlers:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -1847,6 +1894,7 @@ ActionController::Base.rescue_handlers=:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -1875,6 +1923,7 @@ ActionController::Base.rescue_handlers?:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -1911,6 +1960,7 @@ ActionController::Base.respond_to:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -1939,6 +1989,7 @@ ActionController::Base.responders:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -2012,6 +2063,7 @@ ActionController::Base.supports_path?:
   - 0.51.2
   - 0.52.0
   - 0.60.3
+  - 0.60.4
   - branch-castwide-master
 ActionController::Base.thread_cattr_accessor:
   types:
@@ -2082,6 +2134,7 @@ ActionController::Base.urlsafe_csrf_tokens:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -2110,6 +2163,7 @@ ActionController::Base.urlsafe_csrf_tokens=:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -2243,6 +2297,7 @@ ActionController::Base#after_sign_in_path_for:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -2271,6 +2326,7 @@ ActionController::Base#after_sign_out_path_for:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -2299,6 +2355,7 @@ ActionController::Base#alert:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -2327,6 +2384,7 @@ ActionController::Base#allow_forgery_protection:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -2355,6 +2413,7 @@ ActionController::Base#allow_forgery_protection=:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -2383,6 +2442,7 @@ ActionController::Base#allow_params_authentication!:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -2411,6 +2471,7 @@ ActionController::Base#any_templates?:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -2448,6 +2509,7 @@ ActionController::Base#authenticate_with_http_token:
   - undefined
   skip:
   - 0.60.3
+  - 0.60.4
   - branch-castwide-master
 ActionController::Base#available_action?:
   types:
@@ -2490,6 +2552,7 @@ ActionController::Base#bypass_sign_in:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -2526,6 +2589,7 @@ ActionController::Base#cancel_registration_path:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -2554,6 +2618,7 @@ ActionController::Base#cancel_registration_url:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -2586,6 +2651,7 @@ ActionController::Base#collect_mimes_from_class_level:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -2653,6 +2719,7 @@ ActionController::Base#default_protect_from_forgery:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -2681,6 +2748,7 @@ ActionController::Base#default_protect_from_forgery=:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -2713,6 +2781,7 @@ ActionController::Base#default_static_extension:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -2741,6 +2810,7 @@ ActionController::Base#default_static_extension=:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -2769,6 +2839,7 @@ ActionController::Base#default_url_options:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -2797,6 +2868,7 @@ ActionController::Base#default_url_options=:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -2825,6 +2897,7 @@ ActionController::Base#default_url_options?:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -2862,6 +2935,7 @@ ActionController::Base#devise_controller?:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -2890,6 +2964,7 @@ ActionController::Base#devise_parameter_sanitizer:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -2908,6 +2983,7 @@ ActionController::Base#duplicable?:
   - 0.51.2
   - 0.52.0
   - 0.60.3
+  - 0.60.4
   - branch-castwide-master
 ActionController::Base#edit_polymorphic_path:
   types:
@@ -2933,6 +3009,7 @@ ActionController::Base#edit_polymorphic_path:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -2961,6 +3038,7 @@ ActionController::Base#edit_polymorphic_url:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -2989,6 +3067,7 @@ ActionController::Base#enable_fragment_cache_logging:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -3017,6 +3096,7 @@ ActionController::Base#enable_fragment_cache_logging=:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -3045,6 +3125,7 @@ ActionController::Base#etag_with_template_digest:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -3073,6 +3154,7 @@ ActionController::Base#etag_with_template_digest=:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -3101,6 +3183,7 @@ ActionController::Base#etag_with_template_digest?:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -3129,6 +3212,7 @@ ActionController::Base#etaggers:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -3157,6 +3241,7 @@ ActionController::Base#etaggers=:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -3185,6 +3270,7 @@ ActionController::Base#etaggers?:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -3229,6 +3315,7 @@ ActionController::Base#forgery_protection_origin_check:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -3257,6 +3344,7 @@ ActionController::Base#forgery_protection_origin_check=:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -3285,6 +3373,7 @@ ActionController::Base#forgery_protection_strategy:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -3313,6 +3402,7 @@ ActionController::Base#forgery_protection_strategy=:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -3354,6 +3444,7 @@ ActionController::Base#fragment_cache_keys:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -3382,6 +3473,7 @@ ActionController::Base#fragment_cache_keys=:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -3410,6 +3502,7 @@ ActionController::Base#fragment_cache_keys?:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -3444,6 +3537,7 @@ ActionController::Base#head:
   - 0.51.2
   - 0.52.0
   - 0.60.3
+  - 0.60.4
   - branch-castwide-master
 ActionController::Base#headers:
   types:
@@ -3478,6 +3572,7 @@ ActionController::Base#helpers_path:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -3506,6 +3601,7 @@ ActionController::Base#helpers_path=:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -3534,6 +3630,7 @@ ActionController::Base#helpers_path?:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -3562,6 +3659,7 @@ ActionController::Base#hotwire_native_app?:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -3576,6 +3674,7 @@ ActionController::Base#html_safe?:
   - 0.51.2
   - 0.52.0
   - 0.60.3
+  - 0.60.4
   - branch-castwide-master
 ActionController::Base#http_basic_authenticate_or_request_with:
   types:
@@ -3613,6 +3712,7 @@ ActionController::Base#include_all_helpers:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -3641,6 +3741,7 @@ ActionController::Base#include_all_helpers=:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -3669,6 +3770,7 @@ ActionController::Base#include_all_helpers?:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -3713,6 +3815,7 @@ ActionController::Base#is_flashing_format?:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -3741,6 +3844,7 @@ ActionController::Base#is_navigational_format?:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -3773,6 +3877,7 @@ ActionController::Base#locale:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -3801,6 +3906,7 @@ ActionController::Base#locale=:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -3843,6 +3949,7 @@ ActionController::Base#log_warning_on_csrf_failure:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -3871,6 +3978,7 @@ ActionController::Base#log_warning_on_csrf_failure=:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -3911,6 +4019,7 @@ ActionController::Base#main_app:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -3948,6 +4057,7 @@ ActionController::Base#middleware_stack:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -3976,6 +4086,7 @@ ActionController::Base#middleware_stack=:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -4004,6 +4115,7 @@ ActionController::Base#middleware_stack?:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -4032,6 +4144,7 @@ ActionController::Base#mimes_for_respond_to:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -4060,6 +4173,7 @@ ActionController::Base#mimes_for_respond_to=:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -4088,6 +4202,7 @@ ActionController::Base#mimes_for_respond_to?:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -4116,6 +4231,7 @@ ActionController::Base#new_polymorphic_path:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -4144,6 +4260,7 @@ ActionController::Base#new_polymorphic_url:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -4176,6 +4293,7 @@ ActionController::Base#notice:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -4212,6 +4330,7 @@ ActionController::Base#per_form_csrf_tokens:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -4240,6 +4359,7 @@ ActionController::Base#per_form_csrf_tokens=:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -4268,6 +4388,7 @@ ActionController::Base#perform_caching:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -4296,6 +4417,7 @@ ActionController::Base#perform_caching=:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -4362,6 +4484,7 @@ ActionController::Base#raise_on_missing_translations:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -4390,6 +4513,7 @@ ActionController::Base#raise_on_missing_translations=:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -4418,6 +4542,7 @@ ActionController::Base#raise_on_open_redirects:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -4446,6 +4571,7 @@ ActionController::Base#raise_on_open_redirects=:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -4478,6 +4604,7 @@ ActionController::Base#recede_or_redirect_back_or_to:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -4506,6 +4633,7 @@ ActionController::Base#recede_or_redirect_to:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -4546,6 +4674,7 @@ ActionController::Base#refresh_or_redirect_back_or_to:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -4574,6 +4703,7 @@ ActionController::Base#refresh_or_redirect_to:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -4639,6 +4769,7 @@ ActionController::Base#request_forgery_protection_token:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -4667,6 +4798,7 @@ ActionController::Base#request_forgery_protection_token=:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -4695,6 +4827,7 @@ ActionController::Base#request_format:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -4744,6 +4877,7 @@ ActionController::Base#rescue_handlers:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -4772,6 +4906,7 @@ ActionController::Base#rescue_handlers=:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -4800,6 +4935,7 @@ ActionController::Base#rescue_handlers?:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -4840,6 +4976,7 @@ ActionController::Base#respond_with:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -4868,6 +5005,7 @@ ActionController::Base#responder:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -4896,6 +5034,7 @@ ActionController::Base#responder=:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -4924,6 +5063,7 @@ ActionController::Base#responder?:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -4969,6 +5109,7 @@ ActionController::Base#resume_or_redirect_back_or_to:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -4997,6 +5138,7 @@ ActionController::Base#resume_or_redirect_to:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -5039,6 +5181,7 @@ ActionController::Base#show_detailed_exceptions?:
   - 0.51.2
   - 0.52.0
   - 0.60.3
+  - 0.60.4
   - branch-castwide-master
 ActionController::Base#sign_in:
   types:
@@ -5064,6 +5207,7 @@ ActionController::Base#sign_in:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -5092,6 +5236,7 @@ ActionController::Base#sign_in_and_redirect:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -5120,6 +5265,7 @@ ActionController::Base#sign_out:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -5148,6 +5294,7 @@ ActionController::Base#sign_out_all_scopes:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -5176,6 +5323,7 @@ ActionController::Base#sign_out_and_redirect:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -5204,6 +5352,7 @@ ActionController::Base#signed_in?:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -5232,6 +5381,7 @@ ActionController::Base#signed_in_root_path:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -5274,6 +5424,7 @@ ActionController::Base#store_location_for:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -5302,6 +5453,7 @@ ActionController::Base#stored_location_for:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -5391,6 +5543,7 @@ ActionController::Base#view_paths:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master

--- a/spec/definitions/activejob.yml
+++ b/spec/definitions/activejob.yml
@@ -171,6 +171,7 @@ ActiveJob::Base.default_priority:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -199,6 +200,7 @@ ActiveJob::Base.default_priority=:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -227,6 +229,7 @@ ActiveJob::Base.default_queue_name:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -255,6 +258,7 @@ ActiveJob::Base.default_queue_name=:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -328,6 +332,7 @@ ActiveJob::Base.duplicable?:
   - 0.51.2
   - 0.52.0
   - 0.60.3
+  - 0.60.4
   - branch-castwide-master
 ActiveJob::Base.execute:
   types:
@@ -360,6 +365,7 @@ ActiveJob::Base.html_safe?:
   - 0.51.2
   - 0.52.0
   - 0.60.3
+  - 0.60.4
   - branch-castwide-master
 ActiveJob::Base.in?:
   types:
@@ -397,6 +403,7 @@ ActiveJob::Base.log_arguments:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -425,6 +432,7 @@ ActiveJob::Base.log_arguments=:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -453,6 +461,7 @@ ActiveJob::Base.log_arguments?:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -481,6 +490,7 @@ ActiveJob::Base.logger:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -509,6 +519,7 @@ ActiveJob::Base.logger=:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -609,6 +620,7 @@ ActiveJob::Base.priority:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -637,6 +649,7 @@ ActiveJob::Base.priority=:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -665,6 +678,7 @@ ActiveJob::Base.priority?:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -733,6 +747,7 @@ ActiveJob::Base.queue_name:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -761,6 +776,7 @@ ActiveJob::Base.queue_name=:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -789,6 +805,7 @@ ActiveJob::Base.queue_name?:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -817,6 +834,7 @@ ActiveJob::Base.queue_name_delimiter:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -845,6 +863,7 @@ ActiveJob::Base.queue_name_delimiter=:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -873,6 +892,7 @@ ActiveJob::Base.queue_name_delimiter?:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -910,6 +930,7 @@ ActiveJob::Base.queue_name_prefix:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -938,6 +959,7 @@ ActiveJob::Base.queue_name_prefix=:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -966,6 +988,7 @@ ActiveJob::Base.queue_name_prefix?:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -1035,6 +1058,7 @@ ActiveJob::Base.rescue_handlers:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -1063,6 +1087,7 @@ ActiveJob::Base.rescue_handlers=:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -1091,6 +1116,7 @@ ActiveJob::Base.rescue_handlers?:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -1143,6 +1169,7 @@ ActiveJob::Base.retry_jitter:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -1171,6 +1198,7 @@ ActiveJob::Base.retry_jitter=:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -1233,6 +1261,7 @@ ActiveJob::Base.skip_after_callbacks_if_terminated:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -1261,6 +1290,7 @@ ActiveJob::Base.skip_after_callbacks_if_terminated=:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -1371,6 +1401,7 @@ ActiveJob::Base#duplicable?:
   - 0.51.2
   - 0.52.0
   - 0.60.3
+  - 0.60.4
   - branch-castwide-master
 ActiveJob::Base#enqueue:
   types:
@@ -1422,6 +1453,7 @@ ActiveJob::Base#html_safe?:
   - 0.51.2
   - 0.52.0
   - 0.60.3
+  - 0.60.4
   - branch-castwide-master
 ActiveJob::Base#in?:
   types:
@@ -1488,6 +1520,7 @@ ActiveJob::Base#logger=:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -1558,6 +1591,7 @@ ActiveJob::Base#queue_adapter:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -1594,6 +1628,7 @@ ActiveJob::Base#queue_name_prefix:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -1622,6 +1657,7 @@ ActiveJob::Base#queue_name_prefix=:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -1650,6 +1686,7 @@ ActiveJob::Base#queue_name_prefix?:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -1682,6 +1719,7 @@ ActiveJob::Base#rescue_handlers:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -1710,6 +1748,7 @@ ActiveJob::Base#rescue_handlers=:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -1738,6 +1777,7 @@ ActiveJob::Base#rescue_handlers?:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -1786,6 +1826,7 @@ ActiveJob::Base#serialize:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master

--- a/spec/definitions/activerecord.yml
+++ b/spec/definitions/activerecord.yml
@@ -55,6 +55,7 @@ ActiveRecord::Base.action_on_strict_loading_violation:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -83,6 +84,7 @@ ActiveRecord::Base.action_on_strict_loading_violation=:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -292,6 +294,7 @@ ActiveRecord::Base.application_record_class:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -320,6 +323,7 @@ ActiveRecord::Base.application_record_class=:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -415,6 +419,7 @@ ActiveRecord::Base.attachment_reflections?:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -599,6 +604,7 @@ ActiveRecord::Base.attributes_for_inspect?:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -735,6 +741,7 @@ ActiveRecord::Base.belongs_to_required_by_default?:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -753,6 +760,7 @@ ActiveRecord::Base.blank?:
   - 0.51.2
   - 0.52.0
   - 0.60.3
+  - 0.60.4
   - branch-castwide-master
 ActiveRecord::Base.broadcast_target_default:
   types:
@@ -1273,6 +1281,7 @@ ActiveRecord::Base.default_role:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -1301,6 +1310,7 @@ ActiveRecord::Base.default_role=:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -1329,6 +1339,7 @@ ActiveRecord::Base.default_role?:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -1406,6 +1417,7 @@ ActiveRecord::Base.default_shard:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -1434,6 +1446,7 @@ ActiveRecord::Base.default_shard=:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -1462,6 +1475,7 @@ ActiveRecord::Base.default_shard?:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -1676,6 +1690,7 @@ ActiveRecord::Base.duplicable?:
   - 0.51.2
   - 0.52.0
   - 0.60.3
+  - 0.60.4
   - branch-castwide-master
 ActiveRecord::Base.eager_load:
   types:
@@ -1705,6 +1720,7 @@ ActiveRecord::Base.encrypted_attributes:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -1733,6 +1749,7 @@ ActiveRecord::Base.encrypted_attributes=:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -1761,6 +1778,7 @@ ActiveRecord::Base.encrypted_attributes?:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -1880,6 +1898,7 @@ ActiveRecord::Base.find:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -1909,6 +1928,7 @@ ActiveRecord::Base.find_by:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -2121,6 +2141,7 @@ ActiveRecord::Base.has_many_inversing:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -2149,6 +2170,7 @@ ActiveRecord::Base.has_many_inversing=:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -2177,6 +2199,7 @@ ActiveRecord::Base.has_many_inversing?:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -2244,6 +2267,7 @@ ActiveRecord::Base.html_safe?:
   - 0.51.2
   - 0.52.0
   - 0.60.3
+  - 0.60.4
   - branch-castwide-master
 ActiveRecord::Base.i18n_scope:
   types:
@@ -2257,6 +2281,7 @@ ActiveRecord::Base.i18n_scope:
   - 0.55.alpha
   - 0.56.alpha
   - 0.60.3
+  - 0.60.4
   - branch-castwide-master
 ActiveRecord::Base.ids:
   types:
@@ -2294,6 +2319,7 @@ ActiveRecord::Base.immutable_strings_by_default:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -2322,6 +2348,7 @@ ActiveRecord::Base.immutable_strings_by_default=:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -2350,6 +2377,7 @@ ActiveRecord::Base.immutable_strings_by_default?:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -2493,6 +2521,7 @@ ActiveRecord::Base.inheritance_column?:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -2639,6 +2668,7 @@ ActiveRecord::Base.legacy_connection_handling:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -2667,6 +2697,7 @@ ActiveRecord::Base.legacy_connection_handling=:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -2794,6 +2825,7 @@ ActiveRecord::Base.logger?:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -3007,6 +3039,7 @@ ActiveRecord::Base.param_delimiter?:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -3035,6 +3068,7 @@ ActiveRecord::Base.partial_inserts:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -3063,6 +3097,7 @@ ActiveRecord::Base.partial_inserts=:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -3091,6 +3126,7 @@ ActiveRecord::Base.partial_inserts?:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -3119,6 +3155,7 @@ ActiveRecord::Base.partial_updates:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -3147,6 +3184,7 @@ ActiveRecord::Base.partial_updates=:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -3175,6 +3213,7 @@ ActiveRecord::Base.partial_updates?:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -3231,6 +3270,7 @@ ActiveRecord::Base.pluck:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -3302,6 +3342,7 @@ ActiveRecord::Base.present?:
   - 0.51.2
   - 0.52.0
   - 0.60.3
+  - 0.60.4
   - branch-castwide-master
 ActiveRecord::Base.primary_abstract_class:
   types:
@@ -3376,6 +3417,7 @@ ActiveRecord::Base.primary_key_prefix_type?:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -3425,6 +3467,7 @@ ActiveRecord::Base.queues:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -3453,6 +3496,7 @@ ActiveRecord::Base.queues=:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -3683,6 +3727,7 @@ ActiveRecord::Base.reset_counters:
   - 0.51.2
   - 0.52.0
   - 0.60.3
+  - 0.60.4
   - branch-castwide-master
 ActiveRecord::Base.reset_locking_column:
   types:
@@ -3945,6 +3990,7 @@ ActiveRecord::Base.shard_selector:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -3973,6 +4019,7 @@ ActiveRecord::Base.shard_selector=:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -4001,6 +4048,7 @@ ActiveRecord::Base.shard_selector?:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -4042,6 +4090,7 @@ ActiveRecord::Base.signed_id_verifier_secret:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -4069,6 +4118,7 @@ ActiveRecord::Base.signed_id_verifier_secret=:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -4097,6 +4147,7 @@ ActiveRecord::Base.signed_id_verifier_secret?:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -4204,6 +4255,7 @@ ActiveRecord::Base.store_full_class_name:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -4232,6 +4284,7 @@ ActiveRecord::Base.store_full_class_name=:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -4260,6 +4313,7 @@ ActiveRecord::Base.store_full_class_name?:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -4328,6 +4382,7 @@ ActiveRecord::Base.strict_loading_by_default:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -4356,6 +4411,7 @@ ActiveRecord::Base.strict_loading_by_default=:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -4384,6 +4440,7 @@ ActiveRecord::Base.strict_loading_by_default?:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -4429,6 +4486,7 @@ ActiveRecord::Base.suppress_multiple_database_warning:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -4457,6 +4515,7 @@ ActiveRecord::Base.suppress_multiple_database_warning=:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -4626,6 +4685,7 @@ ActiveRecord::Base.time_zone_aware_attributes?:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -4707,6 +4767,7 @@ ActiveRecord::Base.to_adapter:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -5057,6 +5118,7 @@ ActiveRecord::Base.where:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -5120,6 +5182,7 @@ ActiveRecord::Base#<=>:
   - 0.51.2
   - 0.52.0
   - 0.60.3
+  - 0.60.4
   - branch-castwide-master
 ActiveRecord::Base#==:
   types:
@@ -5372,6 +5435,7 @@ ActiveRecord::Base#automatic_scope_inversing:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -5400,6 +5464,7 @@ ActiveRecord::Base#automatic_scope_inversing?:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -5426,6 +5491,7 @@ ActiveRecord::Base#blank?:
   - 0.51.2
   - 0.52.0
   - 0.60.3
+  - 0.60.4
   - branch-castwide-master
 ActiveRecord::Base#broadcast_action:
   types:
@@ -5770,6 +5836,7 @@ ActiveRecord::Base#column_for_attribute:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -5840,6 +5907,7 @@ ActiveRecord::Base#default_role:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -5868,6 +5936,7 @@ ActiveRecord::Base#default_role?:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -5914,6 +5983,7 @@ ActiveRecord::Base#default_shard:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -5942,6 +6012,7 @@ ActiveRecord::Base#default_shard?:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -6021,6 +6092,7 @@ ActiveRecord::Base#duplicable?:
   - 0.51.2
   - 0.52.0
   - 0.60.3
+  - 0.60.4
   - branch-castwide-master
 ActiveRecord::Base#encode_with:
   types:
@@ -6058,6 +6130,7 @@ ActiveRecord::Base#encrypted_attributes:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -6086,6 +6159,7 @@ ActiveRecord::Base#encrypted_attributes=:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -6114,6 +6188,7 @@ ActiveRecord::Base#encrypted_attributes?:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -6186,6 +6261,7 @@ ActiveRecord::Base#html_safe?:
   - 0.51.2
   - 0.52.0
   - 0.60.3
+  - 0.60.4
   - branch-castwide-master
 ActiveRecord::Base#id:
   types:
@@ -6363,6 +6439,7 @@ ActiveRecord::Base#logger?:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -6443,6 +6520,7 @@ ActiveRecord::Base#param_delimiter=:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -6471,6 +6549,7 @@ ActiveRecord::Base#partial_inserts:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -6499,6 +6578,7 @@ ActiveRecord::Base#partial_inserts?:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -6527,6 +6607,7 @@ ActiveRecord::Base#partial_updates:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -6555,6 +6636,7 @@ ActiveRecord::Base#partial_updates?:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -6605,6 +6687,7 @@ ActiveRecord::Base#present?:
   - 0.51.2
   - 0.52.0
   - 0.60.3
+  - 0.60.4
   - branch-castwide-master
 ActiveRecord::Base#pretty_print:
   types:
@@ -6630,6 +6713,7 @@ ActiveRecord::Base#pretty_print:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -6684,6 +6768,7 @@ ActiveRecord::Base#primary_key_prefix_type?:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -6896,6 +6981,7 @@ ActiveRecord::Base#signed_id_verifier_secret?:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -6946,6 +7032,7 @@ ActiveRecord::Base#store_full_class_name:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -6974,6 +7061,7 @@ ActiveRecord::Base#store_full_class_name?:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -7090,6 +7178,7 @@ ActiveRecord::Base#time_zone_aware_attributes?:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -7136,6 +7225,7 @@ ActiveRecord::Base#to_gid:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -7164,6 +7254,7 @@ ActiveRecord::Base#to_gid_param:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -7192,6 +7283,7 @@ ActiveRecord::Base#to_global_id:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -7245,6 +7337,7 @@ ActiveRecord::Base#to_sgid:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -7273,6 +7366,7 @@ ActiveRecord::Base#to_sgid_param:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -7301,6 +7395,7 @@ ActiveRecord::Base#to_signed_global_id:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -7361,6 +7456,7 @@ ActiveRecord::Base#type_for_attribute:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -7417,6 +7513,7 @@ ActiveRecord::Base#validate!:
   - 0.51.2
   - 0.52.0
   - 0.60.3
+  - 0.60.4
   - branch-castwide-master
 ActiveRecord::Base#validates_absence_of:
   types:

--- a/spec/definitions/application.yml
+++ b/spec/definitions/application.yml
@@ -1,7 +1,7 @@
 ---
 Rails::Application.<=>:
   types:
-  - '-1'
+  - "-1"
   - '0'
   - '1'
   - nil
@@ -18,6 +18,7 @@ Rails::Application.<=>:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-castwide-master
 Rails::Application.abstract_railtie?:
   types:
@@ -180,6 +181,7 @@ Rails::Application.duplicable?:
   - 0.51.2
   - 0.52.0
   - 0.60.3
+  - 0.60.4
   - branch-castwide-master
 Rails::Application.eager_load!:
   types:
@@ -205,6 +207,7 @@ Rails::Application.eager_load!:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -248,6 +251,7 @@ Rails::Application.html_safe?:
   - 0.51.2
   - 0.52.0
   - 0.60.3
+  - 0.60.4
   - branch-castwide-master
 Rails::Application.in?:
   types:
@@ -281,6 +285,7 @@ Rails::Application.initializer:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -309,6 +314,7 @@ Rails::Application.initializers:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -337,6 +343,7 @@ Rails::Application.initializers_chain:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -365,6 +372,7 @@ Rails::Application.initializers_for:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -604,6 +612,7 @@ Rails::Application.yaml_tag:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -713,6 +722,7 @@ Rails::Application#default_url_options:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -741,6 +751,7 @@ Rails::Application#default_url_options=:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -760,6 +771,7 @@ Rails::Application#duplicable?:
   - 0.51.2
   - 0.52.0
   - 0.60.3
+  - 0.60.4
   - branch-castwide-master
 Rails::Application#eager_load!:
   types:
@@ -802,6 +814,7 @@ Rails::Application#engine_name:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -841,6 +854,7 @@ Rails::Application#html_safe?:
   - 0.51.2
   - 0.52.0
   - 0.60.3
+  - 0.60.4
   - branch-castwide-master
 Rails::Application#importmap:
   types:
@@ -866,6 +880,7 @@ Rails::Application#importmap:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -894,6 +909,7 @@ Rails::Application#importmap=:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -958,6 +974,7 @@ Rails::Application#isolated?:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -1023,6 +1040,7 @@ Rails::Application#middleware:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -1064,6 +1082,7 @@ Rails::Application#paths:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -1110,6 +1129,7 @@ Rails::Application#railtie_name:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -1174,6 +1194,7 @@ Rails::Application#root:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master

--- a/spec/definitions/core/Array.yml
+++ b/spec/definitions/core/Array.yml
@@ -109,6 +109,7 @@ Array.duplicable?:
   - 0.51.2
   - 0.52.0
   - 0.60.3
+  - 0.60.4
   - branch-castwide-master
 Array.html_safe?:
   types:
@@ -120,6 +121,7 @@ Array.html_safe?:
   - 0.51.2
   - 0.52.0
   - 0.60.3
+  - 0.60.4
   - branch-castwide-master
 Array.in?:
   types:
@@ -279,6 +281,7 @@ Array#compact_blank:
   - 0.55.alpha
   - 0.57.0
   - 0.60.3
+  - 0.60.4
   - branch-castwide-master
 Array#compact_blank!:
   types:
@@ -303,6 +306,7 @@ Array#duplicable?:
   - 0.51.2
   - 0.52.0
   - 0.60.3
+  - 0.60.4
   - branch-castwide-master
 Array#exclude?:
   types:
@@ -346,6 +350,7 @@ Array#html_safe?:
   - 0.51.2
   - 0.52.0
   - 0.60.3
+  - 0.60.4
   - branch-castwide-master
 Array#in?:
   types:

--- a/spec/definitions/core/Class.yml
+++ b/spec/definitions/core/Class.yml
@@ -57,6 +57,7 @@ Class.attr_internal_naming_format:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -85,6 +86,7 @@ Class.attr_internal_naming_format=:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -165,6 +167,7 @@ Class.duplicable?:
   - 0.51.2
   - 0.52.0
   - 0.60.3
+  - 0.60.4
   - branch-castwide-master
 Class.html_safe?:
   types:
@@ -176,6 +179,7 @@ Class.html_safe?:
   - 0.51.2
   - 0.52.0
   - 0.60.3
+  - 0.60.4
   - branch-castwide-master
 Class.in?:
   types:
@@ -410,6 +414,7 @@ Class#duplicable?:
   - 0.51.2
   - 0.52.0
   - 0.60.3
+  - 0.60.4
   - branch-castwide-master
 Class#html_safe?:
   types:
@@ -421,6 +426,7 @@ Class#html_safe?:
   - 0.51.2
   - 0.52.0
   - 0.60.3
+  - 0.60.4
   - branch-castwide-master
 Class#in?:
   types:

--- a/spec/definitions/core/Date.yml
+++ b/spec/definitions/core/Date.yml
@@ -129,6 +129,7 @@ Date.duplicable?:
   - 0.51.2
   - 0.52.0
   - 0.60.3
+  - 0.60.4
   - branch-castwide-master
 Date.find_beginning_of_week!:
   types:
@@ -144,6 +145,7 @@ Date.html_safe?:
   - 0.51.2
   - 0.52.0
   - 0.60.3
+  - 0.60.4
   - branch-castwide-master
 Date.in?:
   types:
@@ -303,6 +305,7 @@ Date#<=>:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -321,6 +324,7 @@ Date#acts_like_date?:
   - 0.51.2
   - 0.52.0
   - 0.60.3
+  - 0.60.4
   - branch-castwide-master
 Date#advance:
   types:
@@ -403,6 +407,7 @@ Date#as_json:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -496,6 +501,7 @@ Date#blank?:
   - 0.51.2
   - 0.52.0
   - 0.60.3
+  - 0.60.4
   - branch-castwide-master
 Date#change:
   types:
@@ -518,6 +524,7 @@ Date#compare_with_coercion:
   - 0.51.2
   - 0.52.0
   - 0.60.3
+  - 0.60.4
   - branch-castwide-master
 Date#days_ago:
   types:
@@ -545,6 +552,7 @@ Date#duplicable?:
   - 0.51.2
   - 0.52.0
   - 0.60.3
+  - 0.60.4
   - branch-castwide-master
 Date#end_of_day:
   types:
@@ -580,6 +588,7 @@ Date#html_safe?:
   - 0.51.2
   - 0.52.0
   - 0.60.3
+  - 0.60.4
   - branch-castwide-master
 Date#in:
   types:
@@ -614,6 +623,7 @@ Date#in_time_zone:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master

--- a/spec/definitions/core/DateTime.yml
+++ b/spec/definitions/core/DateTime.yml
@@ -197,6 +197,7 @@ DateTime.duplicable?:
   - 0.51.2
   - 0.52.0
   - 0.60.3
+  - 0.60.4
   - branch-castwide-master
 DateTime.find_beginning_of_week!:
   types:
@@ -228,6 +229,7 @@ DateTime.html_safe?:
   - 0.51.2
   - 0.52.0
   - 0.60.3
+  - 0.60.4
   - branch-castwide-master
 DateTime.in?:
   types:
@@ -415,6 +417,7 @@ DateTime#+:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -443,6 +446,7 @@ DateTime#-:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -473,6 +477,7 @@ DateTime#<=>:
   - 0.58.2
   - 0.59.0
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -490,6 +495,7 @@ DateTime#acts_like_date?:
   - 0.51.2
   - 0.52.0
   - 0.60.3
+  - 0.60.4
   - branch-castwide-master
 DateTime#acts_like_time?:
   types:
@@ -501,6 +507,7 @@ DateTime#acts_like_time?:
   - 0.51.2
   - 0.52.0
   - 0.60.3
+  - 0.60.4
   - branch-castwide-master
 DateTime#advance:
   types:
@@ -679,6 +686,7 @@ DateTime#as_json:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -1004,6 +1012,7 @@ DateTime#blank?:
   - 0.51.2
   - 0.52.0
   - 0.60.3
+  - 0.60.4
   - branch-castwide-master
 DateTime#change:
   types:
@@ -1038,6 +1047,7 @@ DateTime#compare_with_coercion:
   - 0.58.2
   - 0.59.0
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -1116,6 +1126,7 @@ DateTime#duplicable?:
   - 0.51.2
   - 0.52.0
   - 0.60.3
+  - 0.60.4
   - branch-castwide-master
 DateTime#end_of_day:
   types:
@@ -1259,6 +1270,7 @@ DateTime#html_safe?:
   - 0.51.2
   - 0.52.0
   - 0.60.3
+  - 0.60.4
   - branch-castwide-master
 DateTime#in:
   types:
@@ -2036,6 +2048,7 @@ DateTime#utc_to_local_returns_utc_offset_times:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master

--- a/spec/definitions/core/File.yml
+++ b/spec/definitions/core/File.yml
@@ -113,6 +113,7 @@ File.duplicable?:
   - 0.51.2
   - 0.52.0
   - 0.60.3
+  - 0.60.4
   - branch-castwide-master
 File.html_safe?:
   types:
@@ -124,6 +125,7 @@ File.html_safe?:
   - 0.51.2
   - 0.52.0
   - 0.60.3
+  - 0.60.4
   - branch-castwide-master
 File.in?:
   types:
@@ -280,6 +282,7 @@ File#compact_blank:
   - 0.52.0
   - 0.57.0
   - 0.60.3
+  - 0.60.4
   - branch-castwide-master
 File#deep_dup:
   types:
@@ -295,6 +298,7 @@ File#duplicable?:
   - 0.51.2
   - 0.52.0
   - 0.60.3
+  - 0.60.4
   - branch-castwide-master
 File#exclude?:
   types:
@@ -314,6 +318,7 @@ File#html_safe?:
   - 0.51.2
   - 0.52.0
   - 0.60.3
+  - 0.60.4
   - branch-castwide-master
 File#in?:
   types:
@@ -404,6 +409,7 @@ File#sum:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-better_signature_combination
   - branch-castwide-master
   - branch-castwide-v0.59

--- a/spec/definitions/core/Hash.yml
+++ b/spec/definitions/core/Hash.yml
@@ -109,6 +109,7 @@ Hash.duplicable?:
   - 0.51.2
   - 0.52.0
   - 0.60.3
+  - 0.60.4
   - branch-castwide-master
 Hash.from_trusted_xml:
   types:
@@ -128,6 +129,7 @@ Hash.html_safe?:
   - 0.51.2
   - 0.52.0
   - 0.60.3
+  - 0.60.4
   - branch-castwide-master
 Hash.in?:
   types:
@@ -336,6 +338,7 @@ Hash#deep_stringify_keys!:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -364,6 +367,7 @@ Hash#deep_symbolize_keys:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -392,6 +396,7 @@ Hash#deep_symbolize_keys!:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -422,6 +427,7 @@ Hash#duplicable?:
   - 0.51.2
   - 0.52.0
   - 0.60.3
+  - 0.60.4
   - branch-castwide-master
 Hash#except!:
   types:
@@ -453,6 +459,7 @@ Hash#html_safe?:
   - 0.51.2
   - 0.52.0
   - 0.60.3
+  - 0.60.4
   - branch-castwide-master
 Hash#in?:
   types:

--- a/spec/definitions/core/Integer.yml
+++ b/spec/definitions/core/Integer.yml
@@ -109,6 +109,7 @@ Integer.duplicable?:
   - 0.51.2
   - 0.52.0
   - 0.60.3
+  - 0.60.4
   - branch-castwide-master
 Integer.html_safe?:
   types:
@@ -120,6 +121,7 @@ Integer.html_safe?:
   - 0.51.2
   - 0.52.0
   - 0.60.3
+  - 0.60.4
   - branch-castwide-master
 Integer.in?:
   types:
@@ -262,6 +264,7 @@ Integer#blank?:
   - 0.51.2
   - 0.52.0
   - 0.60.3
+  - 0.60.4
   - branch-castwide-master
 Integer#byte:
   types:
@@ -307,6 +310,7 @@ Integer#duplicable?:
   - 0.51.2
   - 0.52.0
   - 0.60.3
+  - 0.60.4
   - branch-castwide-master
 Integer#exabyte:
   types:
@@ -370,6 +374,7 @@ Integer#html_safe?:
   - 0.51.2
   - 0.52.0
   - 0.60.3
+  - 0.60.4
   - branch-castwide-master
 Integer#in?:
   types:

--- a/spec/definitions/core/Kernel.yml
+++ b/spec/definitions/core/Kernel.yml
@@ -101,6 +101,7 @@ Kernel.duplicable?:
   - 0.51.2
   - 0.52.0
   - 0.60.3
+  - 0.60.4
   - branch-castwide-master
 Kernel.enable_warnings:
   types:
@@ -116,6 +117,7 @@ Kernel.html_safe?:
   - 0.51.2
   - 0.52.0
   - 0.60.3
+  - 0.60.4
   - branch-castwide-master
 Kernel.in?:
   types:

--- a/spec/definitions/core/Module.yml
+++ b/spec/definitions/core/Module.yml
@@ -153,6 +153,7 @@ Module.duplicable?:
   - 0.51.2
   - 0.52.0
   - 0.60.3
+  - 0.60.4
   - branch-castwide-master
 Module.html_safe?:
   types:
@@ -164,6 +165,7 @@ Module.html_safe?:
   - 0.51.2
   - 0.52.0
   - 0.60.3
+  - 0.60.4
   - branch-castwide-master
 Module.in?:
   types:
@@ -390,6 +392,7 @@ Module#duplicable?:
   - 0.51.2
   - 0.52.0
   - 0.60.3
+  - 0.60.4
   - branch-castwide-master
 Module#html_safe?:
   types:
@@ -401,6 +404,7 @@ Module#html_safe?:
   - 0.51.2
   - 0.52.0
   - 0.60.3
+  - 0.60.4
   - branch-castwide-master
 Module#in?:
   types:

--- a/spec/definitions/core/String.yml
+++ b/spec/definitions/core/String.yml
@@ -109,6 +109,7 @@ String.duplicable?:
   - 0.51.2
   - 0.52.0
   - 0.60.3
+  - 0.60.4
   - branch-castwide-master
 String.html_safe?:
   types:
@@ -120,6 +121,7 @@ String.html_safe?:
   - 0.51.2
   - 0.52.0
   - 0.60.3
+  - 0.60.4
   - branch-castwide-master
 String.in?:
   types:
@@ -258,6 +260,7 @@ String#acts_like_string?:
   - 0.51.2
   - 0.52.0
   - 0.60.3
+  - 0.60.4
   - branch-castwide-master
 String#as_json:
   types:
@@ -361,6 +364,7 @@ String#duplicable?:
   - 0.51.2
   - 0.52.0
   - 0.60.3
+  - 0.60.4
   - branch-castwide-master
 String#exclude?:
   types:
@@ -390,6 +394,7 @@ String#ext:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -430,6 +435,7 @@ String#html_safe?:
   - 0.51.2
   - 0.52.0
   - 0.60.3
+  - 0.60.4
   - branch-castwide-master
 String#humanize:
   types:
@@ -524,6 +530,7 @@ String#pathmap:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master

--- a/spec/definitions/core/Time.yml
+++ b/spec/definitions/core/Time.yml
@@ -139,6 +139,7 @@ Time.duplicable?:
   - 0.51.2
   - 0.52.0
   - 0.60.3
+  - 0.60.4
   - branch-castwide-master
 Time.find_zone:
   types:
@@ -169,6 +170,7 @@ Time.html_safe?:
   - 0.51.2
   - 0.52.0
   - 0.60.3
+  - 0.60.4
   - branch-castwide-master
 Time.in?:
   types:
@@ -355,6 +357,7 @@ Time#-:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -386,6 +389,7 @@ Time#<=>:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -404,6 +408,7 @@ Time#acts_like_time?:
   - 0.51.2
   - 0.52.0
   - 0.60.3
+  - 0.60.4
   - branch-castwide-master
 Time#advance:
   types:
@@ -486,6 +491,7 @@ Time#as_json:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -604,6 +610,7 @@ Time#blank?:
   - 0.51.2
   - 0.52.0
   - 0.60.3
+  - 0.60.4
   - branch-castwide-master
 Time#change:
   types:
@@ -626,6 +633,7 @@ Time#compare_with_coercion:
   - 0.51.2
   - 0.52.0
   - 0.60.3
+  - 0.60.4
   - branch-castwide-master
 Time#days_ago:
   types:
@@ -653,6 +661,7 @@ Time#duplicable?:
   - 0.51.2
   - 0.52.0
   - 0.60.3
+  - 0.60.4
   - branch-castwide-master
 Time#end_of_day:
   types:
@@ -708,6 +717,7 @@ Time#html_safe?:
   - 0.51.2
   - 0.52.0
   - 0.60.3
+  - 0.60.4
   - branch-castwide-master
 Time#in:
   types:
@@ -799,6 +809,7 @@ Time#minus_without_coercion:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master
@@ -1016,6 +1027,7 @@ Time#utc_to_local_returns_utc_offset_times:
   - 0.59.0.dev.1
   - 0.59.0.dev.2
   - 0.60.3
+  - 0.60.4
   - branch-2025-09-22
   - branch-better_signature_combination
   - branch-castwide-master

--- a/spec/definitions/routes.yml
+++ b/spec/definitions/routes.yml
@@ -109,6 +109,7 @@ ActionDispatch::Routing::Mapper.duplicable?:
   - 0.51.2
   - 0.52.0
   - 0.60.3
+  - 0.60.4
   - branch-castwide-master
 ActionDispatch::Routing::Mapper.html_safe?:
   types:
@@ -120,6 +121,7 @@ ActionDispatch::Routing::Mapper.html_safe?:
   - 0.51.2
   - 0.52.0
   - 0.60.3
+  - 0.60.4
   - branch-castwide-master
 ActionDispatch::Routing::Mapper.in?:
   types:
@@ -387,6 +389,7 @@ ActionDispatch::Routing::Mapper#duplicable?:
   - 0.51.2
   - 0.52.0
   - 0.60.3
+  - 0.60.4
   - branch-castwide-master
 ActionDispatch::Routing::Mapper#get:
   types:
@@ -406,6 +409,7 @@ ActionDispatch::Routing::Mapper#html_safe?:
   - 0.51.2
   - 0.52.0
   - 0.60.3
+  - 0.60.4
   - branch-castwide-master
 ActionDispatch::Routing::Mapper#in?:
   types:

--- a/spec/solargraph-rails/rails_spec.rb
+++ b/spec/solargraph-rails/rails_spec.rb
@@ -111,7 +111,7 @@ RSpec.describe 'Rails API completion' do
     # covered while it still reports 0.60.3 and drops out of the list the moment
     # that version is bumped. A later version that still has the bug runs the
     # assertions and fails rather than being skipped silently.
-    broken_versions = ['0.59.2', '0.60.3']
+    broken_versions = ['0.59.2', '0.60.3', '0.60.4']
     skip 'block parameter types unresolved; see castwide/solargraph#1288' if broken_versions.include?(Solargraph::VERSION)
 
     expect(completion_at(filename, [8, 10], map)).to include('column')


### PR DESCRIPTION
**Claude:**

**Summary:** Adds Solargraph `0.60.4` to the test matrix and its skip-definition entries, copied from `branch-castwide-master` via `script/copy_definitions.rb` (the same process used for `0.60.3`). Also extends the known-broken-versions list for the still-open castwide/solargraph#1288 migration block-param regression, which `0.60.4` still has.

**Test plan:** `bundle exec rake spec` against Rails 7.0 with `MATRIX_SOLARGRAPH_VERSION` unset (resolves latest, `0.60.4`) passes except one pre-existing-pattern finding: 67 `DateAndTime::Calculations` methods (Date/DateTime) are marked skipped for `0.60.4` but resolve correctly — confirmed via a `0.60.3` control run (0 failures there), so this is a genuine `0.60.4` improvement over what's recorded, left unfixed pending a decision on the correct way to update those 67 entries. CI will additionally exercise the 7.1/7.2/8.0 matrix cells this local run didn't cover.
